### PR TITLE
Fix map rendering and improve GPS distance tracking

### DIFF
--- a/components/fare-calculator.tsx
+++ b/components/fare-calculator.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect, useRef } from "react"
+import { useState, useEffect, useRef, useMemo } from "react"
 import { Card } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -63,6 +63,13 @@ export function FareCalculator() {
   const [coordinates, setCoordinates] = useState<Coordinates[]>([])
   const watchIdRef = useRef<number | null>(null)
 
+  const formattedTrackedDistance = useMemo(() => {
+    if (trackedDistance < 1) {
+      return `${Math.round(trackedDistance * 1000)} m`
+    }
+    return `${trackedDistance.toFixed(2)} km`
+  }, [trackedDistance])
+
   useEffect(() => {
     return () => {
       if (watchIdRef.current !== null) {
@@ -95,8 +102,8 @@ export function FareCalculator() {
             const lastCoord = prev[prev.length - 1]
             const distanceIncrement = calculateDistance(lastCoord, newCoord)
 
-            // Only add distance if movement is significant (more than 10 meters)
-            if (distanceIncrement > 0.01) {
+            // Only add distance if movement is significant (more than ~5 meters)
+            if (distanceIncrement > 0.005) {
               setTrackedDistance((prevDistance) => prevDistance + distanceIncrement)
             }
           }
@@ -295,7 +302,7 @@ export function FareCalculator() {
                   <div className="p-4 rounded-lg bg-primary/5 border border-primary/20">
                     <div className="text-center">
                       <p className="text-sm text-muted-foreground mb-1">Distance Tracked</p>
-                      <p className="text-3xl font-bold text-foreground">{trackedDistance.toFixed(2)} km</p>
+                      <p className="text-3xl font-bold text-foreground">{formattedTrackedDistance}</p>
                     </div>
                   </div>
                 )}

--- a/components/route-map.tsx
+++ b/components/route-map.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from "react"
 import { MapPin } from "lucide-react"
+import "leaflet/dist/leaflet.css"
 
 interface Coordinates {
   latitude: number
@@ -133,6 +134,10 @@ export function RouteMap({ coordinates, isTracking }: RouteMapProps) {
       // Fit map to show entire route
       const bounds = L.latLngBounds(latLngs)
       map.fitBounds(bounds, { padding: [50, 50] })
+      // Ensure map tiles render correctly after layout changes
+      setTimeout(() => {
+        map.invalidateSize()
+      }, 0)
     })
   }, [coordinates, isTracking])
 


### PR DESCRIPTION
## Summary
- import Leaflet's default styles and invalidate the map size so tiles render reliably
- reduce the GPS distance increment filter and improve the tracked distance display formatting

## Testing
- pnpm lint *(fails: command prompts for initial ESLint configuration in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5c43988c083289a21368feb917739